### PR TITLE
Move exporter arg parsing higher and rename to custom otr

### DIFF
--- a/ZAPD/Globals.h
+++ b/ZAPD/Globals.h
@@ -68,7 +68,7 @@ public:
 	bool forceUnaccountedStatic = false;
 	bool otrMode = true;
 	bool buildRawTexture = false;
-	bool onlyGenSohOtr = false;
+	bool onlyGenCustomOtr = false;
 
 	ZRom* rom = nullptr;
 	std::vector<ZFile*> files;


### PR DESCRIPTION
This moves the args parsing for the exporter to happen sooner so that all args are parsed before the early escape when only generating a custom otr via `--norom`

These changes can be tested out on this SoH branch https://github.com/Archez/Shipwright/tree/use-custom-asset-dir