### PR TITLE
Place shared scenes in their own location

### DIFF
--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -333,11 +333,13 @@ std::string ZResource::GetSourceOutputHeader([[maybe_unused]] const std::string&
 		std::string xmlPath = StringHelper::Replace(parent->GetXmlFilePath().string(), "\\", "/");
 
 		if (StringHelper::Contains(outName, "_room_") || StringHelper::Contains(outName, "_scene")) {
-			prefix = "scenes";
-			if (StringHelper::Contains(xmlPath, "dungeons/")) {
-				prefix += "/nonmq";
-			} else {
-				prefix += "/shared";
+			prefix = "scenes/shared";
+
+			// Regex for xml paths that are dungeons with unique MQ variants (only the main dungeon, not boss rooms)
+			std::regex dungeonsWithMQ(R"(((ydan)|(ddan)|(bdan)|(Bmori1)|(HIDAN)|(MIZUsin)|(jyasinzou)|(HAKAdan)|(HAKAdanCH)|(ice_doukutu)|(men)|(ganontika))\.xml)");
+
+			if (StringHelper::Contains(xmlPath, "dungeons/") && std::regex_search(xmlPath, dungeonsWithMQ)) {
+				prefix = "scenes/nonmq";
 			}
 		}
 		else if (StringHelper::Contains(xmlPath, "objects/"))

--- a/ZAPD/ZResource.cpp
+++ b/ZAPD/ZResource.cpp
@@ -332,8 +332,14 @@ std::string ZResource::GetSourceOutputHeader([[maybe_unused]] const std::string&
 
 		std::string xmlPath = StringHelper::Replace(parent->GetXmlFilePath().string(), "\\", "/");
 
-		if (StringHelper::Contains(outName, "_room_") || StringHelper::Contains(outName, "_scene"))
-			prefix = "scenes/nonmq";
+		if (StringHelper::Contains(outName, "_room_") || StringHelper::Contains(outName, "_scene")) {
+			prefix = "scenes";
+			if (StringHelper::Contains(xmlPath, "dungeons/")) {
+				prefix += "/nonmq";
+			} else {
+				prefix += "/shared";
+			}
+		}
 		else if (StringHelper::Contains(xmlPath, "objects/"))
 			prefix = "objects";
 		else if (StringHelper::Contains(xmlPath, "textures/"))


### PR DESCRIPTION
This PR makes it so that headers for shared scenes are do not use /nonmq in the name, and that only explicit main dungeons that have nonmq/mq variants will have those paths.

This is to help reduce duplicate files that need patching for texture packs.

Can be tested out here: https://github.com/HarbourMasters/Shipwright/pull/3191