### PR TITLE
Fix compilation for OpenBSD

### DIFF
--- a/ZAPD/CMakeLists.txt
+++ b/ZAPD/CMakeLists.txt
@@ -479,6 +479,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "CafeOS")
 else()
 	set(THREADS_PREFER_PTHREAD_FLAG ON)
 	find_package(Threads REQUIRED)
+	find_package(Backtrace REQUIRED)
 	set(ADDITIONAL_LIBRARY_DEPENDENCIES
 		"ZAPDUtils;"
 		-Wl,--whole-archive $<TARGET_LINKER_FILE_DIR:OTRExporter>/$<TARGET_LINKER_FILE_NAME:OTRExporter> -Wl,--no-whole-archive
@@ -486,6 +487,7 @@ else()
 		PNG::PNG
 		${CMAKE_DL_LIBS}
 		Threads::Threads
+		${Backtrace_LIBRARY}
 	)
 endif()
 


### PR DESCRIPTION
Adds an explicit include for the backtrace library.