### PR TITLE
Atomic Reporting Pointers

### DIFF
--- a/ZAPD/ExecutableMain.cpp
+++ b/ZAPD/ExecutableMain.cpp
@@ -1,7 +1,8 @@
 #include <stdio.h>
+#include <atomic>
 
 extern "C" int zapd_main(int argc, char* argv[]);
-extern "C" int zapd_report(int argc, char* argv[], size_t* extractCount, size_t* totalExtract);
+extern "C" int zapd_report(int argc, char* argv[], std::atomic<size_t>* extractCount, std::atomic<size_t>* totalExtract);
 
 int main(int argc, char* argv[]) {
     return zapd_report(argc, argv, nullptr, nullptr);

--- a/ZAPD/Main.cpp
+++ b/ZAPD/Main.cpp
@@ -1,4 +1,5 @@
 #include "Globals.h"
+#include <atomic>
 #include <Utils/DiskFile.h>
 #include <Utils/Path.h>
 #include <Utils/Directory.h>
@@ -132,7 +133,7 @@ void BuildAssetTexture(const fs::path& pngFilePath, TextureType texType, const f
 void BuildAssetBackground(const fs::path& imageFilePath, const fs::path& outPath);
 void BuildAssetBlob(const fs::path& blobFilePath, const fs::path& outPath);
 ZFileMode ParseFileMode(const std::string& buildMode, ExporterSet* exporterSet);
-int HandleExtract(ZFileMode fileMode, ExporterSet* exporterSet, size_t* extractCount = nullptr, size_t* totalExtract = nullptr);
+int HandleExtract(ZFileMode fileMode, ExporterSet* exporterSet, std::atomic<size_t>* extractCount = nullptr, std::atomic<size_t>* totalExtract = nullptr);
 int ExtractFunc(int workerID, int fileListSize, std::string fileListItem, ZFileMode fileMode);
 
 std::atomic<unsigned int> numWorkersLeft = 0;
@@ -141,7 +142,7 @@ extern const char gBuildHash[];
 
 extern void ImportExporters();
 
-extern "C" int zapd_report(int argc, char* argv[], size_t* extractCount, size_t* totalExtract)
+extern "C" int zapd_report(int argc, char* argv[], std::atomic<size_t>* extractCount, std::atomic<size_t>* totalExtract)
 {
 	int returnCode = 0;
 
@@ -639,7 +640,7 @@ void Arg_SetXMLMode(int& i, char* argv[])
 	}
 }
 
-int HandleExtract(ZFileMode fileMode, ExporterSet* exporterSet, size_t* extractCount, size_t* totalExtract)
+int HandleExtract(ZFileMode fileMode, ExporterSet* exporterSet, std::atomic<size_t>* extractCount, std::atomic<size_t>* totalExtract)
 {
 	bool procFileModeSuccess = false;
 


### PR DESCRIPTION
Convert `size_t` reporting pointers to `std::atomic<size_t>` for thread safety.