### PR TITLE
initialize some uninitialized things

### DIFF
--- a/ZAPD/OtherStructs/SkinLimbStructs.h
+++ b/ZAPD/OtherStructs/SkinLimbStructs.h
@@ -104,7 +104,7 @@ public:
 	uint16_t totalVtxCount = 0;
 	uint16_t limbModifCount;     // Length of limbModifications
 	segptr_t limbModifications;  // SkinLimbModif*
-	segptr_t dlist;              // Gfx*
+	segptr_t dlist = SEGMENTED_NULL;  // Gfx*
 
 	std::vector<SkinLimbModif> limbModifications_arr;
 	// ZDisplayList* unk_8_dlist = nullptr;

--- a/ZAPD/OtherStructs/SkinLimbStructs.h
+++ b/ZAPD/OtherStructs/SkinLimbStructs.h
@@ -101,7 +101,7 @@ public:
 	size_t GetRawDataSize() const override;
 
 public:
-	uint16_t totalVtxCount;
+	uint16_t totalVtxCount = 0;
 	uint16_t limbModifCount;     // Length of limbModifications
 	segptr_t limbModifications;  // SkinLimbModif*
 	segptr_t dlist;              // Gfx*

--- a/ZAPD/ZRoom/Commands/SetMesh.h
+++ b/ZAPD/ZRoom/Commands/SetMesh.h
@@ -141,7 +141,7 @@ public:
 class SetMesh : public ZRoomCommand
 {
 public:
-	uint8_t data;
+	uint8_t data = 0;
 	uint8_t meshHeaderType;
 	std::shared_ptr<PolygonTypeBase> polyType;
 

--- a/ZAPD/ZRoom/Commands/SetMesh.h
+++ b/ZAPD/ZRoom/Commands/SetMesh.h
@@ -44,8 +44,8 @@ protected:
 class RoomShapeImageMultiBgEntry : public ZResource
 {
 public:
-	uint16_t unk_00;
-	uint8_t id;
+	uint16_t unk_00 = 0;
+	uint8_t id = 0;
 	segptr_t source;
 	uint32_t unk_0C;
 	uint32_t tlut;


### PR DESCRIPTION
## Initialize `SkinAnimatedLimbData::totalVtxCount` to `0` and `dlist` to `SEGMENTED_NULL`

`totalVtxCount` and `dlist` had no default values, so limbs that don't go through `ParseRawData` (non-`SkinType_Animated` limbs) would export uninitialized data into the OTR file.

the only flow where we get intentional data for these is

https://github.com/HarbourMasters/ZAPDTR/blob/74a8e9d92214ce9e028aa1c51c1be7622e98d200/ZAPD/ZLimb.cpp#L114

in

https://github.com/HarbourMasters/ZAPDTR/blob/74a8e9d92214ce9e028aa1c51c1be7622e98d200/ZAPD/ZLimb.cpp#L105-L117

the rest of

https://github.com/HarbourMasters/ZAPDTR/blob/74a8e9d92214ce9e028aa1c51c1be7622e98d200/ZAPD/ZLimb.cpp#L61

leaves them uninitialized.

**`totalVtxCount`** is written unconditionally and read back as `skinVtxCnt`.

this means we read garbage in [`OTRExporter_SkeletonLimb::Save`](https://github.com/HarbourMasters/OTRExporter/blob/8d98be81a26024ee0c9794a7224dd7a992cc687e/OTRExporter/SkeletonLimbExporter.cpp#L29)

```cpp
void OTRExporter_SkeletonLimb::Save(ZResource* res, const fs::path& outPath, BinaryWriter* writer)
{
	[...]
	writer->Write((uint16_t)limb->segmentStruct.totalVtxCount);
```

**`dlist`** (also in `OTRExporter_SkeletonLimb::Save`) is [checked against `SEGMENTED_NULL` and passed through `GETSEGOFFSET` into `GetDeclaration`](https://github.com/HarbourMasters/OTRExporter/blob/8d98be81a26024ee0c9794a7224dd7a992cc687e/OTRExporter/SkeletonLimbExporter.cpp#L61-L63).

```cpp
	if (limb->segmentStruct.dlist != SEGMENTED_NULL)
	{
		auto skinGfxDecl = limb->parent->GetDeclaration(GETSEGOFFSET(limb->segmentStruct.dlist));
```

 If the garbage value's offset happened to match a key in the declarations map, it would write that declaration's path as `skinDList2` into the OTR file.
 
## Others

they weren't getting initialized so they had garbage

### Initialize `SetMesh::data` to `0`
### Initialize `RoomShapeImageMultiBgEntry::unk_00` and `id` to `0`
